### PR TITLE
Add "repository" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "repository": "React30/React30.com",
   "scripts": {
     "start": "heroku local -f Procfile.local",
     "build": "npm run build-assets && npm run build-lib",


### PR DESCRIPTION
This removes the warning when installing this project:

```shell
  npm i
npm WARN React30.com No repository field.
npm WARN React30.com No license field.
```

Regarding license, I'm not sure what you'd prefer since this isn't like your `expect` project @mjackson.   