### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 stats.json
 public/assets
 lib
+node_modules


### PR DESCRIPTION
This is purely to make searching easier (Atom automatically ignores anything in `.gitignore`) and simplify the noise when working with Git.

Also, I'm really curious if `node_modules` is necessary or not for Heroku.

Reason being, in the past when I've deployed with Heroku it ran `npm pack` (or similar) to bundle my current project and _skipped_ running `npm install` on the server during deployment.

